### PR TITLE
Fix the CI failures on macOS and Linux, and move workflows off Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
             artifact: awman-windows-amd64.exe
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -57,7 +57,7 @@ jobs:
         run: cp target/${{ matrix.target }}/release/awman.exe ${{ matrix.artifact }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
@@ -69,10 +69,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -99,7 +99,7 @@ jobs:
 
       - name: Create release with notes
         if: steps.notes.outputs.exists == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.version }}
           body_path: ${{ steps.notes.outputs.file }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Create release without notes
         if: steps.notes.outputs.exists != 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.version }}
           generate_release_notes: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: Fast checks (lint, fmt, clippy, hermetic tests)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -20,7 +20,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: fast
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -55,7 +55,7 @@ jobs:
           toolchain: "1.94.0"
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -76,7 +76,7 @@ jobs:
     runs-on: macos-latest
     needs: fast
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -84,7 +84,7 @@ jobs:
           toolchain: "1.94.0"
 
       - name: Cache cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry

--- a/src/command/commands/skill_library.rs
+++ b/src/command/commands/skill_library.rs
@@ -398,24 +398,55 @@ mod tests {
     /// HTTPS URL a fresh `PullTarget::Slug` builds to a local `file://` remote,
     /// so a fresh clone never touches the network. Injected additively via
     /// `GIT_CONFIG_COUNT` so the developer's global git config is untouched.
+    /// Puts the `GIT_CONFIG_*` trio back the way it was found, on the normal
+    /// path and while unwinding alike.
+    struct RestoreGitConfigEnv {
+        prev: [(&'static str, Option<String>); 3],
+    }
+
+    impl Drop for RestoreGitConfigEnv {
+        fn drop(&mut self) {
+            for (key, value) in &self.prev {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
     fn with_github_insteadof<F, R>(github_url: &str, local_url: &str, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        let _g = GIT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let keys = ["GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0"];
-        let prev: Vec<Option<String>> = keys.iter().map(|k| std::env::var(k).ok()).collect();
-        std::env::set_var("GIT_CONFIG_COUNT", "1");
+        let _lock = GIT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // `GIT_CONFIG_COUNT` is restored first for the same reason it is set
+        // last: with it absent, git ignores the indexed keys entirely.
+        let prev = [
+            ("GIT_CONFIG_COUNT", std::env::var("GIT_CONFIG_COUNT").ok()),
+            ("GIT_CONFIG_KEY_0", std::env::var("GIT_CONFIG_KEY_0").ok()),
+            (
+                "GIT_CONFIG_VALUE_0",
+                std::env::var("GIT_CONFIG_VALUE_0").ok(),
+            ),
+        ];
+
+        // These are process-global, and the lock only serializes the tests
+        // that inject them — every *other* test's `git` child still inherits
+        // whatever is set at the moment it is spawned. Publish the indexed
+        // pair before the count that makes git read it: while the count is
+        // unset the pair is inert, so no concurrent git can observe a count
+        // promising a key that has not been written yet, which git rejects
+        // outright with "missing config key GIT_CONFIG_KEY_0".
         std::env::set_var("GIT_CONFIG_KEY_0", format!("url.{local_url}.insteadOf"));
         std::env::set_var("GIT_CONFIG_VALUE_0", github_url);
-        let out = f();
-        for (k, v) in keys.iter().zip(prev) {
-            match v {
-                Some(v) => std::env::set_var(k, v),
-                None => std::env::remove_var(k),
-            }
-        }
-        out
+        std::env::set_var("GIT_CONFIG_COUNT", "1");
+
+        // Declared after `_lock`, so it restores the environment before the
+        // lock is released — and unwinds it even if `f` panics, which a plain
+        // sequence of `set_var` calls at the end of the function would not.
+        let _restore = RestoreGitConfigEnv { prev };
+        f()
     }
 
     // ─── resolve_pull_target ──────────────────────────────────────────────────

--- a/src/data/fs/path_guard.rs
+++ b/src/data/fs/path_guard.rs
@@ -7,20 +7,19 @@
 //! root uses this to guarantee the resolved path cannot escape the root via
 //! `..` or a crafted component.
 
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use crate::data::error::DataError;
 
-/// Verify that `resolved` stays under `root`. Both are canonicalized when they
-/// exist on disk (falling back to their lexical form when they do not), so the
-/// check holds for not-yet-created directories as well as existing ones.
+/// Verify that `resolved` stays under `root`. Both are resolved with
+/// [`canonicalize_lenient`], so the check holds for not-yet-created
+/// directories as well as existing ones.
 ///
 /// Returns `DataError::InvalidPath { path: resolved, reason }` when `resolved`
 /// escapes `root`.
 pub fn validate_under_root(root: &Path, resolved: &Path, reason: &str) -> Result<(), DataError> {
-    let canonical_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
-    let canonical_resolved =
-        std::fs::canonicalize(resolved).unwrap_or_else(|_| resolved.to_path_buf());
+    let canonical_root = canonicalize_lenient(root);
+    let canonical_resolved = canonicalize_lenient(resolved);
     if !canonical_resolved.starts_with(&canonical_root) {
         return Err(DataError::InvalidPath {
             path: resolved.to_path_buf(),
@@ -28,6 +27,50 @@ pub fn validate_under_root(root: &Path, resolved: &Path, reason: &str) -> Result
         });
     }
     Ok(())
+}
+
+/// Canonicalize as much of `path` as exists on disk.
+///
+/// `std::fs::canonicalize` fails outright when the leaf does not exist yet, and
+/// the previous fallback — treating the whole path lexically — compared a
+/// symlink-resolved root against an unresolved child. Wherever the root sits
+/// behind a symlink (macOS resolves `/var/folders/...` to
+/// `/private/var/folders/...`) that made a perfectly contained path look like
+/// an escape.
+///
+/// So canonicalize the deepest existing ancestor, then re-apply the trailing
+/// components lexically. Those components do not exist, so none of them can be
+/// a symlink and resolving them lexically cannot hide a traversal — a trailing
+/// `..` pops a directory exactly as the kernel would.
+fn canonicalize_lenient(path: &Path) -> PathBuf {
+    // Walk up to the deepest existing ancestor, collecting what we skip past.
+    let mut tail: Vec<Component<'_>> = Vec::new();
+    let mut cursor = path;
+    let base = loop {
+        if let Ok(canonical) = std::fs::canonicalize(cursor) {
+            break canonical;
+        }
+        let mut components = cursor.components();
+        let Some(last) = components.next_back() else {
+            // Nothing exists anywhere along the path, so keep it lexical.
+            break PathBuf::new();
+        };
+        tail.push(last);
+        cursor = components.as_path();
+    };
+
+    let mut resolved = base;
+    for component in tail.into_iter().rev() {
+        match component {
+            Component::CurDir => {}
+            // `pop` at the root is a no-op, matching the kernel's `/.. == /`.
+            Component::ParentDir => {
+                resolved.pop();
+            }
+            other => resolved.push(other.as_os_str()),
+        }
+    }
+    resolved
 }
 
 #[cfg(test)]
@@ -66,5 +109,28 @@ mod tests {
         std::fs::create_dir_all(tmp.path().join("escaped")).unwrap();
         let resolved = root.join("..").join("escaped");
         assert!(validate_under_root(&root, &resolved, "escape").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn accepts_a_not_yet_created_child_of_a_symlinked_root() {
+        // Every macOS temp dir is reached through a symlink
+        // (`/var/folders/...` -> `/private/var/folders/...`), so a root that
+        // exists and a child that does not must still resolve to the same
+        // prefix. Reproduced here with an explicit symlink so the guarantee is
+        // pinned on every platform, not just the one that exposed it.
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real");
+        std::fs::create_dir_all(real.join("tasks")).unwrap();
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let root = link.join("tasks");
+        let resolved = root.join("not-created-yet");
+        assert!(validate_under_root(&root, &resolved, "containment").is_ok());
+
+        // The symlink must not become an escape hatch either.
+        let escape = root.join("..").join("..").join("elsewhere");
+        assert!(validate_under_root(&root, &escape, "containment").is_err());
     }
 }

--- a/src/engine/auth/credential.rs
+++ b/src/engine/auth/credential.rs
@@ -183,6 +183,64 @@ pub enum HostCredentialSource {
     HostFile { path: PathBuf },
 }
 
+/// Where one process should read host credentials from.
+///
+/// Production binds only a home directory and lets each descriptor pick the
+/// platform's native store — for Claude that is the Keychain on macOS and
+/// `~/.claude/.credentials.json` everywhere else.
+///
+/// The reason this type exists rather than every caller invoking
+/// `(spec.source)(resolver)` directly: [`claude_source`] branches on
+/// `cfg!(target_os = "macos")` and, on that branch, ignores the resolver
+/// entirely. A caller that rebinds the home directory to isolate itself
+/// therefore isolates nothing on macOS and silently reads the developer's real
+/// Keychain. Binding the source explicitly with [`CredentialBinding::to_file`]
+/// makes that isolation hold on every platform instead of on two out of three.
+///
+/// [`claude_source`]: fn@claude_source
+#[derive(Clone, Debug)]
+pub struct CredentialBinding {
+    resolver: AuthPathResolver,
+    /// When set, used verbatim in place of the descriptor's platform default.
+    explicit: Option<HostCredentialSource>,
+}
+
+impl CredentialBinding {
+    /// Bind a home directory and let each descriptor choose the platform's
+    /// native credential store. The production constructor.
+    pub fn platform_default(resolver: AuthPathResolver) -> Self {
+        Self {
+            resolver,
+            explicit: None,
+        }
+    }
+
+    /// Bind an explicit host credential FILE, overriding the platform default.
+    ///
+    /// This is what makes a temp-HOME fixture mean the same thing on macOS as
+    /// it does on Linux. It reads the file and never mounts it (INV-2), exactly
+    /// as the non-macOS platform default does.
+    pub fn to_file(resolver: AuthPathResolver, path: impl Into<PathBuf>) -> Self {
+        Self {
+            resolver,
+            explicit: Some(HostCredentialSource::HostFile { path: path.into() }),
+        }
+    }
+
+    /// The home directory this binding resolves agent paths against.
+    pub fn resolver(&self) -> &AuthPathResolver {
+        &self.resolver
+    }
+
+    /// The source `spec` should read from under this binding.
+    pub fn source_for(&self, spec: &RefreshableCredentialSpec) -> HostCredentialSource {
+        match &self.explicit {
+            Some(source) => source.clone(),
+            None => (spec.source)(&self.resolver),
+        }
+    }
+}
+
 /// How to cause the HOST to rotate its own credential.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum HostRefreshAction {

--- a/src/engine/credential_refresh/monitor.rs
+++ b/src/engine/credential_refresh/monitor.rs
@@ -21,7 +21,9 @@ use std::time::{Duration, Instant, SystemTime};
 
 use crate::data::fs::auth_paths::AuthPathResolver;
 use crate::data::session::AgentName;
-use crate::engine::auth::credential::{CredentialFile, CredentialFingerprint, CredentialReadError};
+use crate::engine::auth::credential::{
+    CredentialBinding, CredentialFile, CredentialFingerprint, CredentialReadError,
+};
 use crate::engine::auth::keychain::refreshable_spec_for;
 use crate::engine::auth::RefreshableCredentialDelivery;
 use crate::engine::ready::{refresh_host_credential, HostRefreshOutcome};
@@ -103,7 +105,7 @@ struct AgentState {
 pub struct CredentialRefreshMonitor {
     config: MonitorConfig,
     registry: LeaseRegistry,
-    resolver: AuthPathResolver,
+    binding: CredentialBinding,
     state: Mutex<HashMap<String, AgentState>>,
     /// Serializes host-refresh operations so the single-use refresh token is
     /// never raced by the tick loop and a concurrent `refresh_now` (INV-4).
@@ -118,14 +120,26 @@ impl CredentialRefreshMonitor {
         Self::with_resolver(config, resolver)
     }
 
-    /// Construct a monitor bound to an explicit credential resolver instead of
-    /// the process HOME/keychain. Used by tests so the tick loop never reads a
-    /// developer's real credential nor spawns a real host ping (F3).
+    /// Construct a monitor rooted at an explicit home directory, still reading
+    /// whichever credential store the platform uses natively.
+    ///
+    /// NOTE for tests: on macOS the Claude descriptor reads the Keychain and
+    /// ignores the home directory, so this alone does NOT isolate a test from
+    /// the developer's real credential. Use [`Self::with_binding`] with
+    /// [`CredentialBinding::to_file`] for an isolation that holds on every
+    /// platform.
     pub fn with_resolver(config: MonitorConfig, resolver: AuthPathResolver) -> Arc<Self> {
+        Self::with_binding(config, CredentialBinding::platform_default(resolver))
+    }
+
+    /// Construct a monitor bound to an explicit credential source, so the tick
+    /// loop never reads a developer's real credential nor spawns a real host
+    /// ping (F3) — on any platform.
+    pub fn with_binding(config: MonitorConfig, binding: CredentialBinding) -> Arc<Self> {
         Arc::new(Self {
             config,
             registry: LeaseRegistry::new(),
-            resolver,
+            binding,
             state: Mutex::new(HashMap::new()),
             refresh_gate: tokio::sync::Mutex::new(()),
             thread_started: std::sync::Once::new(),
@@ -289,7 +303,7 @@ impl CredentialRefreshMonitor {
                 reason: CredentialReadError::Unsupported,
             };
         };
-        let source = (spec.source)(&self.resolver);
+        let source = self.binding.source_for(spec);
 
         let snapshot = match (spec.read)(&source) {
             Ok(snapshot) => snapshot,
@@ -325,7 +339,7 @@ impl CredentialRefreshMonitor {
         // its last-known-good file — loudly, never silently.
         let mut stale_remediation: Option<String> = None;
         let snapshot = if near_expiry {
-            match refresh_host_credential(spec, &self.resolver).await {
+            match refresh_host_credential(spec, &self.binding).await {
                 HostRefreshOutcome::Advanced { .. } => match (spec.read)(&source) {
                     Ok(fresh) => fresh,
                     Err(reason) => {
@@ -631,14 +645,6 @@ mod tests {
     /// HIGH-7 / INV-7 defense 3: the monitor never RECREATES a staged file that
     /// a live lease's container has deleted — a missing target is a skip, not a
     /// write. Only present-but-drifted files are repaired.
-    ///
-    /// Not run on macOS. `claude_source` branches on `cfg!(target_os =
-    /// "macos")`, so the host credential there is the Keychain and the resolver
-    /// is ignored entirely — a credential planted under a temp HOME is never
-    /// read, and the fixture cannot be built (the setup read returns
-    /// `NotFound`). The reconciliation logic under test is platform
-    /// independent; only the source of the host credential is not.
-    #[cfg(not(target_os = "macos"))]
     #[test]
     fn reconcile_skips_missing_target_instead_of_recreating() {
         let home = tempfile::tempdir().unwrap();
@@ -654,21 +660,25 @@ mod tests {
         )
         .unwrap();
 
-        let resolver = AuthPathResolver::at_home(home.path());
+        // Bind the credential source to the planted FILE, not to the platform
+        // default: on macOS the default is the Keychain, which would ignore
+        // this temp HOME and read the developer's real credential.
+        let binding =
+            CredentialBinding::to_file(AuthPathResolver::at_home(home.path()), &host_file);
         let spec = refreshable_spec_for(&AgentName::new("claude").unwrap()).unwrap();
-        let snapshot = (spec.read)(&(spec.source)(&resolver)).unwrap();
+        let snapshot = (spec.read)(&binding.source_for(spec)).unwrap();
         let fingerprint = CredentialFingerprint::of(&snapshot);
 
         let staged = tempfile::tempdir().unwrap();
         let staged_path = staged.path().join(".credentials.json");
         // Deliberately do NOT create the staged file: the container "deleted" it.
 
-        let monitor = CredentialRefreshMonitor::with_resolver(
+        let monitor = CredentialRefreshMonitor::with_binding(
             MonitorConfig {
                 refresh_threshold: Duration::from_secs(60),
                 tick_interval: Duration::from_secs(3600),
             },
-            resolver,
+            binding,
         );
         let delivery = RefreshableCredentialDelivery {
             agent: AgentName::new("claude").unwrap(),
@@ -696,10 +706,6 @@ mod tests {
     /// unchanged (same fingerprint). The monitor no longer skips the write just
     /// because the host fingerprint matches `last_materialized`.
     ///
-    /// Not run on macOS, for the same reason as
-    /// [`reconcile_skips_missing_target_instead_of_recreating`]: the host
-    /// credential there comes from the Keychain, not from the resolver's HOME.
-    #[cfg(not(target_os = "macos"))]
     #[test]
     fn reconcile_repairs_drifted_staged_file_when_host_unchanged() {
         let home = tempfile::tempdir().unwrap();
@@ -718,9 +724,11 @@ mod tests {
         .unwrap();
 
         let spec = refreshable_spec_for(&AgentName::new("claude").unwrap()).unwrap();
-        let resolver = AuthPathResolver::at_home(home.path());
-        let source = (spec.source)(&resolver);
-        let snapshot = (spec.read)(&source).unwrap();
+        // Explicit file binding, so this fixture means the same thing on macOS
+        // as it does on Linux (see the sibling test).
+        let binding =
+            CredentialBinding::to_file(AuthPathResolver::at_home(home.path()), &host_file);
+        let snapshot = (spec.read)(&binding.source_for(spec)).unwrap();
         let fingerprint = CredentialFingerprint::of(&snapshot);
         let file = (spec.materialize)(&snapshot);
 
@@ -730,12 +738,12 @@ mod tests {
 
         // Use a long tick so only our explicit refresh_now reconciles (the
         // background thread stays parked between our call and the assertion).
-        let monitor = CredentialRefreshMonitor::with_resolver(
+        let monitor = CredentialRefreshMonitor::with_binding(
             MonitorConfig {
                 refresh_threshold: Duration::from_secs(60),
                 tick_interval: Duration::from_secs(3600),
             },
-            resolver,
+            binding,
         );
         let delivery = RefreshableCredentialDelivery {
             agent: AgentName::new("claude").unwrap(),
@@ -764,12 +772,18 @@ mod tests {
 
     #[test]
     fn register_seeds_state_and_counts_lease() {
-        // A per-test temp HOME, so nothing here can touch the developer's real
-        // file-backed credential and no two tests share a home directory.
+        // A per-test temp HOME bound as an explicit FILE source, so nothing
+        // here can touch the developer's real credential on ANY platform and no
+        // two tests share a home directory. The file is deliberately absent:
+        // the tick thread's read is a guaranteed miss rather than, on macOS, a
+        // Keychain hit on whatever the developer happens to be logged into.
         let home = tempfile::tempdir().unwrap();
-        let monitor = CredentialRefreshMonitor::with_resolver(
+        let monitor = CredentialRefreshMonitor::with_binding(
             MonitorConfig::default(),
-            AuthPathResolver::at_home(home.path()),
+            CredentialBinding::to_file(
+                AuthPathResolver::at_home(home.path()),
+                home.path().join(".claude/.credentials.json"),
+            ),
         );
         let staged = tempfile::tempdir().unwrap();
         let agent = AgentName::new("claude").unwrap();
@@ -785,9 +799,8 @@ mod tests {
         // Seeding is asserted through the `seed_state` call `register` itself
         // makes, BEFORE any monitor thread exists. Asserting it after
         // `register` would race that thread's first tick, which reads the host
-        // credential (a keychain lookup on macOS, so a temp HOME does not make
-        // it a guaranteed miss) and then legitimately rewrites either the
-        // failure counter or `last_materialized`.
+        // credential and then legitimately rewrites either the failure counter
+        // or `last_materialized`.
         monitor.seed_state(&delivery);
         assert_eq!(
             monitor

--- a/src/engine/credential_refresh/monitor.rs
+++ b/src/engine/credential_refresh/monitor.rs
@@ -631,6 +631,14 @@ mod tests {
     /// HIGH-7 / INV-7 defense 3: the monitor never RECREATES a staged file that
     /// a live lease's container has deleted — a missing target is a skip, not a
     /// write. Only present-but-drifted files are repaired.
+    ///
+    /// Not run on macOS. `claude_source` branches on `cfg!(target_os =
+    /// "macos")`, so the host credential there is the Keychain and the resolver
+    /// is ignored entirely — a credential planted under a temp HOME is never
+    /// read, and the fixture cannot be built (the setup read returns
+    /// `NotFound`). The reconciliation logic under test is platform
+    /// independent; only the source of the host credential is not.
+    #[cfg(not(target_os = "macos"))]
     #[test]
     fn reconcile_skips_missing_target_instead_of_recreating() {
         let home = tempfile::tempdir().unwrap();
@@ -687,6 +695,11 @@ mod tests {
     /// repaired on the next reconciliation even when the HOST token is
     /// unchanged (same fingerprint). The monitor no longer skips the write just
     /// because the host fingerprint matches `last_materialized`.
+    ///
+    /// Not run on macOS, for the same reason as
+    /// [`reconcile_skips_missing_target_instead_of_recreating`]: the host
+    /// credential there comes from the Keychain, not from the resolver's HOME.
+    #[cfg(not(target_os = "macos"))]
     #[test]
     fn reconcile_repairs_drifted_staged_file_when_host_unchanged() {
         let home = tempfile::tempdir().unwrap();

--- a/src/engine/ready/mod.rs
+++ b/src/engine/ready/mod.rs
@@ -177,9 +177,9 @@ const HOST_REFRESH_REMEDIATION: &str = "run `claude` on the host / check login";
 /// file; it is never promoted to an engine error.
 pub async fn refresh_host_credential(
     spec: &RefreshableCredentialSpec,
-    resolver: &crate::data::fs::auth_paths::AuthPathResolver,
+    binding: &crate::engine::auth::credential::CredentialBinding,
 ) -> HostRefreshOutcome {
-    let source = (spec.source)(resolver);
+    let source = binding.source_for(spec);
     let before = match (spec.read)(&source) {
         Ok(snapshot) => (spec.expiry)(&snapshot),
         Err(reason) => {

--- a/tests/command/skill_libraries.rs
+++ b/tests/command/skill_libraries.rs
@@ -50,7 +50,6 @@ impl EnvGuard {
             .collect();
 
         std::env::set_var("AWMAN_CONFIG_HOME", home);
-        std::env::set_var("GIT_CONFIG_COUNT", remotes.len().to_string());
         for (index, (github_url, local_repo)) in remotes.iter().enumerate() {
             std::env::set_var(
                 format!("GIT_CONFIG_KEY_{index}"),
@@ -58,6 +57,13 @@ impl EnvGuard {
             );
             std::env::set_var(format!("GIT_CONFIG_VALUE_{index}"), github_url);
         }
+        // Last, and dropped first: these vars are process-global, so a `git`
+        // spawned by any concurrently-running test inherits them mid-write.
+        // While `GIT_CONFIG_COUNT` is unset the indexed keys are inert, so
+        // publishing it only once they are all written means no such git ever
+        // sees a count promising a key that is missing — which git rejects
+        // outright rather than ignoring.
+        std::env::set_var("GIT_CONFIG_COUNT", remotes.len().to_string());
         Self { saved }
     }
 }

--- a/tests/data_layer/daemon_primitives.rs
+++ b/tests/data_layer/daemon_primitives.rs
@@ -299,19 +299,38 @@ fn awman_named_test_process() -> Child {
     let tmp = tempfile::tempdir().unwrap();
     let helper = tmp.path().join("awman");
     std::fs::copy(source, &helper).unwrap();
-    let mut child = Command::new(&helper)
-        .args([
-            "--exact",
-            "daemon_guard_helper_process_stays_alive",
-            "--nocapture",
-        ])
-        .env("AWMAN_GUARD_HELPER", "1")
-        .spawn()
-        .unwrap();
-    for _ in 0..100 {
-        if awman::data::fs::daemon_process::is_process_alive(child.id()) {
-            // Once exec has completed, the child no longer needs the copied
-            // file. Dropping the TempDir avoids leaking a test binary.
+    // A concurrent test function forking anywhere in this process can inherit
+    // the still-open write descriptor on `helper`, which makes `execve` report
+    // the file as busy (`ETXTBSY`) until that fork execs and drops it. The
+    // window is short, so retry rather than force `--test-threads=1`.
+    let mut attempt = 0;
+    let mut child = loop {
+        let spawned = Command::new(&helper)
+            .args([
+                "--exact",
+                "daemon_guard_helper_process_stays_alive",
+                "--nocapture",
+            ])
+            .env("AWMAN_GUARD_HELPER", "1")
+            .spawn();
+        match spawned {
+            Ok(child) => break child,
+            Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy && attempt < 20 => {
+                attempt += 1;
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(e) => panic!("spawn awman-named helper process: {e}"),
+        }
+    };
+    // Wait on the *identity*, not merely on liveness. `spawn` returns once the
+    // child exists, and a forked-but-not-yet-exec'd child is already alive
+    // while still reporting the command name it inherited from this thread —
+    // so `is_process_alive` can pass a whole tick before the child looks like
+    // an awman process to the guard under test.
+    for _ in 0..500 {
+        if awman::data::fs::daemon_process::pid_is_awman(child.id()) {
+            // Exec has landed, so the child no longer needs the copied file.
+            // Dropping the TempDir avoids leaking a test binary.
             drop(tmp);
             return child;
         }
@@ -319,7 +338,7 @@ fn awman_named_test_process() -> Child {
     }
     let _ = child.kill();
     let _ = child.wait();
-    panic!("awman-named helper process did not stay alive");
+    panic!("awman-named helper process never presented an awman command name");
 }
 
 #[cfg(unix)]

--- a/tests/data_layer/daemon_primitives.rs
+++ b/tests/data_layer/daemon_primitives.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
 use std::time::Duration;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::sync::Mutex;
 
 use awman::data::config::env::{EnvSnapshot, AWMAN_API_ROOT, AWMAN_SQUAD_ROOT};
@@ -16,7 +16,7 @@ use awman::data::fs::{DaemonGuard, DaemonKind, DaemonPaths, SquadPaths};
 /// A few daemon-spawn tests temporarily replace `PATH` to inject a platform
 /// launcher.  Keep that process-global state serialized across the whole test
 /// module so one injection cannot change another test's meaning.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 static PATH_LOCK: Mutex<()> = Mutex::new(());
 
 fn paths_env(api_root: &Path, squad_root: &Path) -> EnvSnapshot {
@@ -152,9 +152,12 @@ fn spawn_detached_identity_is_distinct_for_api_and_squad() {
     // scoped `HOME` plus a stub `launchctl` on `PATH` exercises it for real.
     #[cfg(target_os = "macos")]
     {
-        use std::sync::Mutex;
-        static ENV_LOCK: Mutex<()> = Mutex::new(());
-        let _lock = ENV_LOCK.lock().unwrap();
+        // The module-wide lock, not a private one: this block installs a
+        // `launchctl` stub that reports *success*, and the spawn-failure test
+        // installs one that reports failure. Two locks over one process-global
+        // `PATH` serialize nothing, and whichever stub happened to be
+        // installed would decide the other test's result.
+        let _lock = PATH_LOCK.lock().unwrap();
         let home = tempfile::tempdir().unwrap();
         let bin_dir = home.path().join("bin");
         std::fs::create_dir_all(&bin_dir).unwrap();
@@ -208,19 +211,25 @@ fn squad_spawn_failure_is_wrapped_with_an_attributable_daemon_message() {
     let tmp = tempfile::tempdir().unwrap();
     let process = daemon(tmp.path(), DaemonKind::Squad);
 
-    // Force the portable `double_fork_spawn` path.  A real systemd-run can
-    // accept a unit before its executable fails, which is correct production
-    // behavior but not a synchronous failure injection.  This tiny stub makes
-    // its availability probe fail so the missing binary is observed here.
-    #[cfg(target_os = "linux")]
+    // Force the portable `double_fork_spawn` path.  Both platform launchers
+    // *accept* a job before its executable fails — a real systemd-run accepts
+    // the unit, and `launchctl load` accepts a plist naming a binary that does
+    // not exist — which is correct production behavior but not a synchronous
+    // failure injection.  Stubbing the launcher so it reports itself
+    // unavailable is what makes the missing binary observable here.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     let _path_guard = {
         let _lock = PATH_LOCK.lock().unwrap();
         let bin_dir = tmp.path().join("bin");
         std::fs::create_dir(&bin_dir).unwrap();
-        let systemd = bin_dir.join("systemd-run");
-        std::fs::write(&systemd, "#!/bin/sh\nexit 1\n").unwrap();
+        let launcher = bin_dir.join(if cfg!(target_os = "macos") {
+            "launchctl"
+        } else {
+            "systemd-run"
+        });
+        std::fs::write(&launcher, "#!/bin/sh\nexit 1\n").unwrap();
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&systemd, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(&launcher, std::fs::Permissions::from_mode(0o755)).unwrap();
         let old_path = std::env::var_os("PATH");
         std::env::set_var("PATH", &bin_dir);
         PathGuard { _lock, old_path }
@@ -240,13 +249,13 @@ fn squad_spawn_failure_is_wrapped_with_an_attributable_daemon_message() {
     );
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 struct PathGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
     old_path: Option<std::ffi::OsString>,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 impl Drop for PathGuard {
     fn drop(&mut self) {
         match self.old_path.take() {

--- a/tests/engine/credential_refresh_integration.rs
+++ b/tests/engine/credential_refresh_integration.rs
@@ -578,11 +578,19 @@ fn docker_e2e_live_container_observes_rotated_fingerprint_and_exited_stage_is_un
     }
     let home = PathBuf::from(std::env::var_os("HOME").unwrap());
     std::fs::create_dir_all(home.join(".claude")).unwrap();
+    // Start FAR from expiry. `register` starts the monitor thread, and
+    // `run_monitor_loop` ticks before it sleeps, so the first tick lands
+    // immediately no matter how long `tick_interval` is. Planting a
+    // near-expiry credential here would let that first tick perform the whole
+    // rotation before the container below is even running: the explicit
+    // `refresh_now` would then find every staged file already current and
+    // report `NotNeeded`, and the container would only ever observe one
+    // fingerprint. Arm the rotation further down, once the container is live.
     std::fs::write(
         host_file(&home),
         payload(
-            "fixture-e2e-expiring",
-            SystemTime::now() + Duration::from_secs(10),
+            "fixture-e2e-initial",
+            SystemTime::now() + Duration::from_secs(7200),
         ),
     )
     .unwrap();
@@ -594,6 +602,22 @@ fn docker_e2e_live_container_observes_rotated_fingerprint_and_exited_stage_is_un
     let monitor = monitor();
     let live_lease = monitor.register(&live_delivery, "awman-e2e-live");
     let exited_lease = monitor.register(&exited_delivery, "awman-e2e-exited");
+    // Barrier on that first tick rather than assuming it is quick: it must be
+    // done reconciling the far-expiry credential before the rotation is armed,
+    // or it could be the one that rotates. A recorded outcome is the signal
+    // that `refresh_agent` ran to completion.
+    let first_tick = std::time::Instant::now();
+    while !monitor
+        .status()
+        .iter()
+        .any(|s| s.agent.as_str() == "claude" && s.last_outcome.is_some())
+    {
+        assert!(
+            first_tick.elapsed() < Duration::from_secs(30),
+            "the monitor's first tick never recorded an outcome"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
     let exited_mount = format!("{}:/root/.claude:ro", exited.path().display());
     assert!(Command::new("docker")
         .args(["run", "--rm", "-v", &exited_mount, "busybox:latest", "true"])
@@ -634,6 +658,19 @@ fn docker_e2e_live_container_observes_rotated_fingerprint_and_exited_stage_is_un
         .spawn()
         .unwrap();
     std::thread::sleep(Duration::from_millis(250));
+    // The container has now read the pre-rotation staged file at least once.
+    // Arm the rotation: a near-expiry host credential is what drives
+    // `refresh_agent` to run the fixture `claude` binary, which copies the
+    // refreshed token over the host file. The next tick is 60s away, so this
+    // `refresh_now` is unambiguously the call that performs it.
+    std::fs::write(
+        host_file(&home),
+        payload(
+            "fixture-e2e-expiring",
+            SystemTime::now() + Duration::from_secs(10),
+        ),
+    )
+    .unwrap();
     let outcome = tokio::runtime::Runtime::new()
         .unwrap()
         .block_on(monitor.refresh_now(&AgentName::new("claude").unwrap(), Duration::from_secs(2)));

--- a/tests/engine/credential_refresh_integration.rs
+++ b/tests/engine/credential_refresh_integration.rs
@@ -15,7 +15,7 @@ use awman::data::session::AgentName;
 use awman::data::session::{Session, SessionOpenOptions, StaticGitRootResolver};
 use awman::data::workflow_definition::Workflow;
 use awman::engine::agent_runtime::frontend::{AgentFrontend, AgentIo, AgentProgress, AgentStatus};
-use awman::engine::auth::credential::{claude_spec, CredentialFingerprint};
+use awman::engine::auth::credential::{claude_spec, CredentialBinding, CredentialFingerprint};
 use awman::engine::auth::RefreshableCredentialDelivery;
 use awman::engine::container::options::ResolvedContainerOptions;
 use awman::engine::container::{
@@ -45,10 +45,21 @@ fn host_file(home: &Path) -> PathBuf {
     home.join(".claude/.credentials.json")
 }
 
+/// Bind the fixture's planted credential FILE explicitly.
+///
+/// `claude_spec().source` returns the Keychain on macOS and ignores the home
+/// directory, so deriving the source from a temp HOME would read whatever the
+/// developer is logged into rather than the fixture — and find nothing on a CI
+/// runner. An explicit file binding makes every test below mean the same thing
+/// on every platform.
+fn binding(home: &Path) -> CredentialBinding {
+    CredentialBinding::to_file(AuthPathResolver::at_home(home), host_file(home))
+}
+
 fn materialized_delivery(home: &Path, staged_root: &Path) -> RefreshableCredentialDelivery {
     let spec = claude_spec();
-    let source = (spec.source)(&AuthPathResolver::at_home(home));
-    let snapshot = (spec.read)(&source).expect("fixture credential must parse");
+    let snapshot =
+        (spec.read)(&binding(home).source_for(spec)).expect("fixture credential must parse");
     let file = (spec.materialize)(&snapshot);
     std::fs::create_dir_all(staged_root).unwrap();
     std::fs::write(staged_root.join(&file.relative_path), &file.contents).unwrap();
@@ -62,23 +73,34 @@ fn materialized_delivery(home: &Path, staged_root: &Path) -> RefreshableCredenti
     }
 }
 
+/// The monitor under test, bound to the fixture child's HOME as an explicit
+/// file source. `CredentialRefreshMonitor::new` would derive the source from
+/// the platform instead, which on macOS means the real Keychain no matter what
+/// HOME says — see [`binding`].
 fn monitor() -> std::sync::Arc<CredentialRefreshMonitor> {
-    CredentialRefreshMonitor::new(MonitorConfig {
-        refresh_threshold: Duration::from_secs(20 * 60),
-        // The direct `refresh_now` calls below are deterministic.  A long tick
-        // avoids a background tick racing a deliberately asserted write count.
-        tick_interval: Duration::from_secs(60),
-    })
+    let home = PathBuf::from(std::env::var_os("HOME").expect("fixture child sets HOME"));
+    CredentialRefreshMonitor::with_binding(
+        MonitorConfig {
+            refresh_threshold: Duration::from_secs(20 * 60),
+            // The direct `refresh_now` calls below are deterministic. A long
+            // tick keeps later background ticks out of the way — but note the
+            // FIRST tick lands immediately on `register`, so a test that needs
+            // to own the rotation must still arrange for that tick to be a
+            // no-op (see the docker e2e test).
+            tick_interval: Duration::from_secs(60),
+        },
+        binding(&home),
+    )
 }
 
 fn child_env() -> bool {
     std::env::var_os("AWMAN_0107_MONITOR_CHILD").is_some()
 }
 
-/// Run this exact test in a fresh process. `CredentialRefreshMonitor::new`
-/// binds its resolver from HOME, and `refresh_host_credential` resolves
-/// `claude` from PATH; a child process makes both substitutions hermetic even
-/// when the parent test binary runs tests in parallel.
+/// Run this exact test in a fresh process. The fixture credential is keyed off
+/// HOME, and `refresh_host_credential` resolves `claude` from PATH; a child
+/// process makes both substitutions hermetic even when the parent test binary
+/// runs tests in parallel.
 fn run_fixture_child(test_name: &str, refresh_mode: &str) {
     let home = tempfile::tempdir().unwrap();
     let bin = home.path().join("bin");

--- a/tests/squad_blockers.rs
+++ b/tests/squad_blockers.rs
@@ -277,7 +277,10 @@ async fn interview_collects_every_field_and_reaches_create_with_one_task() {
     assert_eq!(req.interval_secs, 600, "10m must parse to 600s in Layer 2");
     assert_eq!(
         req.workspace,
-        awman::data::fs::TaskWorkspace::Custom(tmp.path().to_path_buf()),
+        // The answer goes in raw and comes back canonicalized: Layer 2 resolves
+        // the path before storing it, so on macOS the `/var` -> `/private/var`
+        // symlink is already collapsed by the time it reaches the gateway.
+        awman::data::fs::TaskWorkspace::Custom(tmp.path().canonicalize().unwrap()),
         "the interview's custom-folder answer reaches Layer 2 as the workspace choice"
     );
     assert_eq!(req.agent.as_deref(), Some("claude"));

--- a/tests/squad_mutual_exclusion.rs
+++ b/tests/squad_mutual_exclusion.rs
@@ -75,7 +75,29 @@ impl FakeAwmanProcess {
                 Err(e) => panic!("spawn fake awman-named process: {e}"),
             }
         };
-        Self { _dir: dir, child }
+
+        // `spawn` returns once the child *exists*, not once it has finished
+        // `execve`. Until that exec lands, the child's command name is still
+        // the one it inherited from the spawning thread — under `cargo test`
+        // that is a test-function name like `api_running_blo`, which
+        // `pid_is_awman` correctly rejects. A guard checked inside that window
+        // reads the pidfile, decides it names a foreign process, and clears it
+        // as stale, so the daemon that should have been refused starts.
+        //
+        // Wait for the identity the daemon is being stood up to present. It is
+        // the only thing that makes this fixture a stand-in for a real daemon,
+        // so no test may observe it before it holds.
+        let mut child = child;
+        let pid = child.id();
+        for _ in 0..500 {
+            if awman::data::fs::daemon_process::pid_is_awman(pid) {
+                return Self { _dir: dir, child };
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("fake awman-named process (PID {pid}) never presented an awman command name");
     }
 
     fn pid(&self) -> u32 {


### PR DESCRIPTION
Gets the `Tests` workflow green on all three jobs. The failures were real
portability bugs in the tests, not flakes — they only ever reproduced on the
runners because each depends on something the Linux dev environment hides.

## Why this took several rounds

`cargo test` stops at the first failing binary, and the macOS job runs the
same hermetic suite as `fast`. Each fix unblocked the next binary in
alphabetical order, so every push surfaced exactly one new failure rather
than the whole set. The last one was `squad_blockers`, 18th of ~30 — the 13
binaries after it had never executed on macOS on this branch at all.

## What was wrong

**Daemon identity races** (`daemon_primitives`, `squad_mutual_exclusion`).
`pid_is_awman` distinguishes a live daemon from a stale pidfile by reading
the process command name. The fixtures spawned a child and read that name
before `execve` had landed, so they intermittently observed the *spawning*
process's identity instead. They now wait for the identity the fixture
exists to present.

**Symlinked-root containment** (`path_guard`). Path containment compared
unresolved paths, so a root reached through a symlink failed to match itself.

**Host credential isolation** (`credential`, `credential_refresh`). The
refresh monitor read the host credential source directly, so on macOS the
tests picked up the developer's real credentials. The source is now
injectable.

**Workspace canonicalization** (`squad_blockers`). `collect_workspace_choice`
canonicalizes the folder collected in the interview before handing it to
Layer 2, so the stored workspace is the resolved path. The test compared
against the raw temp path — identical on Linux, but macOS temp dirs live
under the `/var` -> `/private/var` symlink. Now matches what the sibling unit
tests in `squad/commands.rs` already assert.

**Node 20 deprecation.** Every job warned that `actions/checkout@v4` and
`actions/cache@v4` were being forced onto Node 24. All actions are bumped to
their latest major, each of which declares `node24` natively.

## Verification

All three jobs pass as of `42023234`:
https://github.com/prettysmartdev/awman/actions/runs/33640181498

The macOS job now runs the suite to completion, so the 13 binaries that had
never executed there are covered.

## Note on `pid_is_awman`

Not a current failure, but worth knowing. On Linux it reads
`/proc/<pid>/comm`, which is the truncated basename. On macOS it shells out
to `ps -o comm=`, which returns the **full executable path** — and the CI
checkout is `/Users/runner/work/awman/awman/...`, so on macOS effectively any
test process's PID matches "awman". Every consumer today either waits for the
match to become true or accepts both outcomes, so nothing breaks. It would
bite a future test that asserts a non-awman process gets refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJ3kXPuuXeb69EvX7Lngui
