### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+checksum = "8d57d423b3c82e89b9a24ca3091fee61f456a26edbd28d26c65906f4bc1dcd8f"
 dependencies = [
  "dirs-sys",
 ]
@@ -3167,9 +3167,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
 
 [[package]]
 name = "socket2"
@@ -3586,9 +3586,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.5+spec-1.1.0"
+version = "1.1.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+checksum = "920602543f0911ab71da12c50d59701da54c196d1a2bf5cb4b75667f137a406a"
 dependencies = [
  "indexmap",
  "serde_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1"
 tracing = "0.1"
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"
-dirs = "6"
+dirs = "7"
 portable-pty = "0.9"
 ratatui = "0.30"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

Brings every third-party dependency up to date as of 2026-09-11.

### Dependency changes

| Crate | Before | After | Kind |
|---|---|---|---|
| `dirs` | 6.0.0 | 7.0.0 | direct, `Cargo.toml` requirement `"6"` -> `"7"` (major) |
| `toml` | 1.1.5+spec-1.1.0 | 1.1.6+spec-1.1.0 | direct, lockfile only |
| `smallvec` | 1.16.0 | 1.16.1 | transitive, lockfile only |

Every other direct dependency (including `[dev-dependencies]` `reqwest`/`wiremock` and the `cfg(unix)` `nix`/`libc` entries) was re-checked against crates.io and is already at its latest stable release. Two transitive crates remain behind latest by upstream choice: `axum` 0.8.9 pins `matchit = "=0.8.4"`, and `generic-array` 0.14.7 only appears on non-Linux targets.

### Code changes required by the upgrades

None. The only breaking change in `dirs` 7.0.0 is that `preference_dir()` on Windows now returns `RoamingAppData` instead of `LocalAppData`. awman only calls `dirs::home_dir()` and `dirs::data_dir()`, whose signatures and behaviour are unchanged, so all call sites compile and behave as before.

### Local validation (Rust 1.94.0, Linux aarch64)

- `make architecture-lint` — OK
- `cargo fmt --check` — OK
- `cargo clippy --all-targets -- -D warnings` — OK, no warnings
- `make test-fast` — all suites pass, 0 failures
- `cargo build --release` — OK
- `make test-full` — **not run locally**: Docker is not installed on the machine used for this change. The "Full tests with Docker (Linux)" CI job covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuRyoRpe5XS1rdw7fpZ2Zt
